### PR TITLE
Set CURLOPT_TCP_KEEPALIVE only if curl 7.25.0 or greater is installed.

### DIFF
--- a/http-cpp/impl/curl_easy_wrap.hpp
+++ b/http-cpp/impl/curl_easy_wrap.hpp
@@ -63,7 +63,9 @@ namespace http {
                 curl_easy_setopt(handle, CURLOPT_HTTP_CONTENT_DECODING, 1);
                 curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION,        1);
                 curl_easy_setopt(handle, CURLOPT_MAXREDIRS,             5); // max 5 redirects
+#if (LIBCURL_VERSION_NUM >= 0x071900)
                 curl_easy_setopt(handle, CURLOPT_TCP_KEEPALIVE,         1);
+#endif // (LIBCURL_VERSION_NUM >= 0x071900)
                 curl_easy_setopt(handle, CURLOPT_ERRORBUFFER,           error_buffer);
             }
 


### PR DESCRIPTION
c.f. http://curl.haxx.se/libcurl/c/curl_easy_setopt.html
