### PR TITLE
Use _wfopen to open file on Windows so it will not fail on non-ASCII file path

### DIFF
--- a/http-cpp/client.cpp
+++ b/http-cpp/client.cpp
@@ -51,14 +51,9 @@ namespace {
         wstr.resize(charCount);
 
         int charsWritten = ::MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wstr[0], charCount);
-        if (charsWritten == 0) 
-        {
-            return L"";
-        }
-        else 
-        {
-            return wstr;
-        }
+        assert(charsWritten != 0);
+
+        return wstr;
     }
 #endif
 
@@ -72,7 +67,7 @@ namespace {
 #ifdef WIN32
             _wfopen(Utf8ToW(filename).c_str(), Utf8ToW(flags).c_str()),
 #else
-			std::fopen(filename.c_str(), flags),
+            std::fopen(filename.c_str(), flags),
 #endif
             [](FILE* f) { if(f) { std::fclose(f); } }
         );

--- a/http-cpp/client.cpp
+++ b/http-cpp/client.cpp
@@ -45,7 +45,7 @@ namespace {
     static inline std::wstring Utf8ToW(const std::string& str)
     {
         assert(str.size() < INT_MAX);
-        int charCount = (int)str.size();
+        int charCount = (int)str.size() + 1;
 
         std::wstring wstr;
         wstr.resize(charCount);

--- a/http-cpp/client.cpp
+++ b/http-cpp/client.cpp
@@ -41,6 +41,23 @@
 
 namespace {
 
+#ifdef WIN32
+    static inline std::wstring Utf8ToW(const std::string& str)
+    {
+        std::wstring wstr;
+        wstr.resize(str.size());
+        int charsWritten = ::MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wstr[0], str.size());
+        if (charsWritten == 0) 
+        {
+            return L"";
+        }
+        else 
+        {
+            return wstr;
+        }
+    }
+#endif
+
     static inline std::shared_ptr<FILE> open_file(
         std::string const& filename,
         const char* const flags
@@ -48,7 +65,11 @@ namespace {
         assert(!filename.empty());
 
         std::shared_ptr<FILE> file(
-            std::fopen(filename.c_str(), flags),
+#ifdef WIN32
+            _wfopen(Utf8ToW(filename).c_str(), Utf8ToW(flags).c_str()),
+#else
+			std::fopen(filename.c_str(), flags),
+#endif
             [](FILE* f) { if(f) { std::fclose(f); } }
         );
 

--- a/http-cpp/client.cpp
+++ b/http-cpp/client.cpp
@@ -44,9 +44,13 @@ namespace {
 #ifdef WIN32
     static inline std::wstring Utf8ToW(const std::string& str)
     {
+        assert(str.size() < INT_MAX);
+        int charCount = (int)str.size();
+
         std::wstring wstr;
-        wstr.resize(str.size());
-        int charsWritten = ::MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wstr[0], str.size());
+        wstr.resize(charCount);
+
+        int charsWritten = ::MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wstr[0], charCount);
         if (charsWritten == 0) 
         {
             return L"";


### PR DESCRIPTION
Because windows uses different encoding for file systems (not UTF-8 but system locale related encoding), it's not possible to convert all non-ASCII unicode characters to make it work for fopen. So this change is to use _wfopen to open file on windows so it works for any characters.