### PR TITLE
Changed date format of x-amz-date header

### DIFF
--- a/http-cpp/aws_s3/client.cpp
+++ b/http-cpp/aws_s3/client.cpp
@@ -56,9 +56,8 @@ http::request http::aws_s3::client::request(
 
     // bypass standard HTTP date header set by CuRL later on
     auto t  = std::time(nullptr);
-    auto tm = *std::gmtime(&t);
     char dateBuf[64];
-    std::strftime(dateBuf, sizeof(dateBuf), "%a, %d %b %Y %H:%M:%S GMT", &tm);
+    std::strftime(dateBuf, sizeof(dateBuf), "%Y%m%dT%H%M%SZ", std::gmtime(&t));
     headers["x-amz-date"] = dateBuf;
 
     std::string httpVerb = op;


### PR DESCRIPTION
S3 requests from windows failed due to date format issue.
The used format was different from the specified one.
See: [http://docs.aws.amazon.com/general/latest/gr/sigv4-date-handling.html](http://docs.aws.amazon.com/general/latest/gr/sigv4-date-handling.html)
Change has been verified on Linux and Windows

@Kosta-Github: Can you please have a look on this change?