### PR TITLE
fix `stat` in `file_size()` on macOS and linux

### DIFF
--- a/http-cpp/client.cpp
+++ b/http-cpp/client.cpp
@@ -90,12 +90,12 @@ namespace {
         }
 #elif defined(__APPLE__)
         struct stat s;
-        if(stat(filename.c_str(), &s) == -1) {
+        if(stat(filename.c_str(), &s) != -1) {
             return static_cast<int64_t>(s.st_size);
         }
 #else
         struct stat64 s;
-        if(stat64(filename.c_str(), &s) == -1) {
+        if(stat64(filename.c_str(), &s) != -1) {
             return static_cast<int64_t>(s.st_size);
         }
 #endif


### PR DESCRIPTION
Hi kosta,

There seems to be a typo as `stat` actually return `-1` on failure. This PR is to fix this small issue.